### PR TITLE
Asset Fingerprint Additional option

### DIFF
--- a/README
+++ b/README
@@ -172,6 +172,15 @@ shell> find public/ -type l -exec rm -i {} \;
 Remove the -i option if you don't want to be prompted to delete each symbolic
 link. Be careful using this as you may delete symlinks you did not want to.
 
+--
+If for some reason you don't want to use the fingerprinted path for some of your assets,
+you can edit the excludes configuration:
+
+AssetFingerprint.excludes = ['^bootstrap'] # defaults to an empty array
+
+This is a list of regular expression to check. If any matches your asset's path,
+then that file will not be fingeprinted.
+
 
 ==============================================================
 More projects at http://blog.eliotsykes.com/my-projects/


### PR DESCRIPTION
Hi,

I've added your plugin to my current project to improve client side  file caching.
But for some files, I'm going to use another caching solution... so I wanted those
ones to be ignored by the plugin.

So I've just added this "excludes" option. Hope you like it!

Cheers,
Damien.
