### PR TITLE
rake asset_fingerprint:symlinks:purge

### DIFF
--- a/lib/asset_fingerprint/symlinker.rb
+++ b/lib/asset_fingerprint/symlinker.rb
@@ -3,6 +3,10 @@ module AssetFingerprint
   def self.generate_all_symlinks
     Asset.generate_all_symlinks
   end
+
+  def self.remove_all_symlinks
+    Asset.remove_all_symlinks
+  end
   
   @@symlink_on_the_fly = true
   def self.symlink_on_the_fly=(value)

--- a/tasks/asset_fingerprint_tasks.rake
+++ b/tasks/asset_fingerprint_tasks.rake
@@ -6,6 +6,12 @@ namespace :asset_fingerprint do
       AssetFingerprint.generate_all_symlinks
       puts "Fingerprinted asset symlinks generated"
     end
+
+    desc 'Removes the fingerprinted symlinks for all of the assets'
+    task :purge => :environment do
+      AssetFingerprint.remove_all_symlinks
+      puts "Fingerprinted asset symlinks purged"
+    end
   end
 
 end


### PR DESCRIPTION
I've added a rake task to purge all of the asset fingerprint symlinks.
